### PR TITLE
Merge ecash review fixes into main

### DIFF
--- a/src/blossom.ts
+++ b/src/blossom.ts
@@ -193,6 +193,7 @@ export async function getBlob(
   serverUrl: string,
   sha256Hash: string,
   ext?: string,
+  verify = false,
 ): Promise<ArrayBuffer> {
   const path = ext ? `${sha256Hash}${ext}` : sha256Hash
   const res = await fetch(`${baseUrl(serverUrl)}/${path}`)
@@ -203,7 +204,17 @@ export async function getBlob(
       res.status,
     )
   }
-  return res.arrayBuffer()
+  const buf = await res.arrayBuffer()
+  if (verify) {
+    const actual = bytesToHex(sha256(new Uint8Array(buf)))
+    if (actual !== sha256Hash) {
+      throw new BlossomError(
+        `Hash mismatch: expected ${sha256Hash}, got ${actual}`,
+        'HASH_MISMATCH',
+      )
+    }
+  }
+  return buf
 }
 
 /**

--- a/src/bolt11.ts
+++ b/src/bolt11.ts
@@ -75,6 +75,8 @@ export type Bolt11Invoice = {
   signature: string
   /** Signature recovery flag (0-3) */
   recoveryFlag: number
+  /** True if payee node key recovery from signature failed */
+  signatureRecoveryFailed?: boolean
   /** Unrecognized tagged fields */
   unknownTags: { tag: number; words: number[] }[]
 }
@@ -265,6 +267,7 @@ export function decode(invoice: string): Bolt11Invoice {
   let description: string | undefined
   let descriptionHash: string | undefined
   let payeeNodeKey: string | undefined
+  let signatureRecoveryFailed = false
   let expiry = 3600
   let minFinalCltvExpiry = 18
   let featureBits: Uint8Array | undefined
@@ -371,7 +374,7 @@ export function decode(invoice: string): Bolt11Invoice {
         .addRecoveryBit(recoveryFlag)
       payeeNodeKey = sig.recoverPublicKey(msgHash).toHex(true)
     } catch {
-      // Recovery failed; payeeNodeKey stays undefined
+      signatureRecoveryFailed = true
     }
   }
 
@@ -393,6 +396,7 @@ export function decode(invoice: string): Bolt11Invoice {
     description,
     descriptionHash,
     payeeNodeKey,
+    signatureRecoveryFailed: signatureRecoveryFailed || undefined,
     minFinalCltvExpiry,
     featureBits,
     metadata,

--- a/src/nip60.ts
+++ b/src/nip60.ts
@@ -168,9 +168,19 @@ export function parseTokenEvent(
     throw new Error(`Expected kind ${TOKEN_KIND}, got ${event.kind}`)
   }
   const data = JSON.parse(selfDecrypt(event.content, secretKey)) as Record<string, unknown>
+  if (!data.mint || !Array.isArray(data.proofs)) {
+    throw new Error('Invalid token event: missing mint or proofs')
+  }
+  const proofs = (data.proofs as Record<string, unknown>[]).map(p => {
+    if (typeof p.id !== 'string' || typeof p.amount !== 'number' ||
+        typeof p.secret !== 'string' || typeof p.C !== 'string') {
+      throw new Error('Invalid Cashu proof: missing required fields (id, amount, secret, C)')
+    }
+    return p as unknown as CashuProof
+  })
   return {
     mint: data.mint as string,
-    proofs: data.proofs as CashuProof[],
+    proofs,
     unit: (data.unit as string) || undefined,
     del: (data.del as string[]) || undefined,
   }


### PR DESCRIPTION
## Summary

PR #44 was merged into the `ecash` branch instead of `main`, so these fixes never landed:

- **NIP-60**: `parseTokenEvent()` validates Cashu proof fields
- **Blossom**: `getBlob()` optional SHA-256 hash verification
- **BOLT-11**: `signatureRecoveryFailed` field on `Bolt11Invoice`

Rebased `e99a533` from `ecash-review-fixes` onto current `main`.

## Test plan

- [ ] `parseTokenEvent()` throws on malformed proofs
- [ ] `getBlob(verify=true)` rejects hash mismatches
- [ ] `decode()` sets `signatureRecoveryFailed` correctly