### PR TITLE
fix(nip22): emit uppercase P for root pubkey

### DIFF
--- a/src/nip22.ts
+++ b/src/nip22.ts
@@ -30,7 +30,11 @@ export function createCommentEventTemplate(content: string, scope: CommentScope)
     tags.push(['I', scope.rootId])
   }
 
-  if (scope.rootPubkey) tags.push(['p', scope.rootPubkey])
+  // NIP-22: uppercase tags refer to the root scope, lowercase to the
+  // immediate parent. The separate root pubkey tag must therefore be 'P',
+  // not 'p' — otherwise the root and parent author tags collide on
+  // top-level comments where parentPubkey is also set later.
+  if (scope.rootPubkey) tags.push(['P', scope.rootPubkey])
 
   // Parent tag (if replying to a comment)
   if (scope.parentId) {
@@ -92,6 +96,9 @@ export function parseComment(event: NostrEvent): CommentScope & { content: strin
       case 'K':
         result.rootKind = parseInt(tag[1], 10)
         break
+      case 'P':
+        result.rootPubkey = tag[1]
+        break
       case 'e':
         result.parentType = 'event'
         result.parentId = tag[1]
@@ -107,6 +114,9 @@ export function parseComment(event: NostrEvent): CommentScope & { content: strin
         break
       case 'k':
         result.parentKind = parseInt(tag[1], 10)
+        break
+      case 'p':
+        result.parentPubkey = tag[1]
         break
     }
   }


### PR DESCRIPTION
NIP-22 distinguishes root vs parent scope by tag casing — uppercase `A`/`E`/`K`/`P` refer to the root event, lowercase `a`/`e`/`k`/`p` to the immediate parent. `createCommentEventTemplate` was emitting a lowercase `p` for the root pubkey, which collides with the parent pubkey tag on replies and makes strict NIP-22 parsers misclassify the author scope.

## Changes

- `createCommentEventTemplate`: emit `['P', rootPubkey]` (was `['p', ...]`).
- `parseComment`: handle `P` (rootPubkey) and `p` (parentPubkey) — both were silently dropped before, leaving the parsed scope incomplete on round-trip.

## Test plan

- [ ] `npm run build` — no type errors.
- [ ] Round-trip a top-level comment through `createCommentEventTemplate` → `parseComment`; `rootPubkey` is preserved.
- [ ] Round-trip a reply through both helpers; `rootPubkey` and `parentPubkey` are both preserved and distinct.
- [ ] Existing consumers reading lowercase `p` for root still work, since the dedicated `p` parse case now correctly maps to `parentPubkey` rather than overwriting `rootPubkey`.