### PR TITLE
rss: fix doubled cover image on import, rehost the cover via Blossom

### DIFF
--- a/docs/api/rss.md
+++ b/docs/api/rss.md
@@ -148,6 +148,7 @@ type ItemToDraftOptions = {
   identifierPrefix?: string
   appendSourceLink?: boolean
   htmlToMarkdown?: (html: string) => string
+  keepLeadingImage?: boolean
 }
 ```
 
@@ -157,6 +158,11 @@ type ItemToDraftOptions = {
 | `identifierPrefix` | `string` | Prepended to the derived `d`-tag identifier (e.g. `'rss-'`). |
 | `appendSourceLink` | `boolean` | If `true` (default), appends `*Originally published at [link](link)*` when the item has a `link`. |
 | `htmlToMarkdown` | `(html) => string` | Override the HTML → Markdown converter (default: turndown). |
+| `keepLeadingImage` | `boolean` | Keep a leading body image even when it duplicates `item.image` (default `false`, see below). |
+
+::: tip Cover image dedupe
+Feeds routinely carry the cover picture twice: as the item image (enclosure / `media:content`) and again as the first element of the body, so plain feed readers still show it. A Nostr client renders the NIP-23 `image` tag **and** the body, which would display the picture twice. By default, when the body's leading image matches `item.image` (same URL ignoring extension and query, so `cover.svg` matches `cover.png?w=600`), it is stripped from the body and only the `image` tag remains. Pass `keepLeadingImage: true` to opt out.
+:::
 
 The `d`-tag is derived as `sha256(guid \|\| link \|\| title)` (16 hex chars). Re-importing the same item produces the same identifier, so the kind 30023 publish will replace any previous draft.
 
@@ -239,7 +245,7 @@ type ImportFeedOptions = {
 | `limit` | `number` | Cap on items to import (after `since` filtering). |
 | `since` | `number` | Skip items published before this unix-seconds timestamp. |
 | `draft` | `ItemToDraftOptions` | Forwarded to [`itemToDraft`](#itemtodraft) for each item. |
-| `blossom` | `{ servers, mode? }` | When set, image URLs are rehosted before signing. |
+| `blossom` | `{ servers, mode? }` | When set, image URLs are rehosted before signing - both the inline body images and the cover in the `image` tag. If the cover fails to rehost, its original URL is kept. |
 | `asDraft` | `boolean` | `true` (default) → kind 30024. `false` → kind 30023 (published). |
 
 ```ts

--- a/src/rss.ts
+++ b/src/rss.ts
@@ -297,6 +297,29 @@ export type ItemToDraftOptions = {
   appendSourceLink?: boolean
   /** Override the HTML→Markdown converter. Defaults to turndown. */
   htmlToMarkdown?: (html: string) => string
+  /** Keep a leading body image even when it duplicates the item image (default false). */
+  keepLeadingImage?: boolean
+}
+
+// A leading markdown image, optionally wrapped in a link.
+const LEADING_IMAGE_RE = /^\s*\[?!\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)(?:\]\([^)\s]*\))?\s*/
+
+// URL minus query, hash, and file extension, so cover.svg matches cover.png.
+function imageStem(url: string): string {
+  return url.split(/[?#]/)[0].replace(/\.[a-z0-9]+$/i, '').toLowerCase()
+}
+
+/**
+ * Feeds routinely carry the cover picture twice: as the item image and again
+ * as the first element of the body (so plain feed readers still show it).
+ * A Nostr client renders the NIP-23 `image` tag AND the body, which would
+ * display the picture twice - so when the leading body image matches the
+ * cover, drop it from the body.
+ */
+function stripLeadingCoverImage(markdown: string, coverUrl: string): string {
+  const m = LEADING_IMAGE_RE.exec(markdown)
+  if (!m || imageStem(m[1]) !== imageStem(coverUrl)) return markdown
+  return markdown.slice(m[0].length).trimStart()
 }
 
 /**
@@ -308,6 +331,10 @@ export type ItemToDraftOptions = {
 export function itemToDraft(item: FeedItem, opts: ItemToDraftOptions = {}): LongFormContent {
   const convert = opts.htmlToMarkdown ?? htmlToMarkdown
   let markdown = convert(item.contentHtml || '').trim()
+
+  if (!opts.keepLeadingImage && item.image) {
+    markdown = stripLeadingCoverImage(markdown, item.image)
+  }
 
   if ((opts.appendSourceLink ?? true) && item.link) {
     markdown += `\n\n---\n\n*Originally published at [${item.link}](${item.link})*`
@@ -344,6 +371,34 @@ export type RehostOptions = {
   authTtl?: number
 }
 
+async function rehostImageUrl(
+  url: string,
+  opts: { server: string; mode: RehostMode; ttl: number; signer: Signer },
+): Promise<BlobDescriptor> {
+  if (opts.mode === 'mirror') {
+    const authTpl = createAuthEventTemplate({
+      action: 'upload',
+      content: 'Mirror image from RSS import',
+      expiration: Math.floor(Date.now() / 1000) + opts.ttl,
+    })
+    const authEvent = (await opts.signer.signEvent(authTpl)) as NostrEvent
+    return mirrorBlob(opts.server, url, authEvent)
+  }
+  const res = await fetch(url)
+  if (!res.ok) throw new RssError(`Image fetch failed: ${res.status}`, 'IMG_FETCH')
+  const data = new Uint8Array(await res.arrayBuffer())
+  const hash = bytesToHex(sha256(data))
+  const authTpl = createAuthEventTemplate({
+    action: 'upload',
+    content: 'Upload image from RSS import',
+    expiration: Math.floor(Date.now() / 1000) + opts.ttl,
+    hashes: [hash],
+    size: data.length,
+  })
+  const authEvent = (await opts.signer.signEvent(authTpl)) as NostrEvent
+  return uploadBlob(opts.server, data, authEvent, res.headers.get('content-type') ?? undefined)
+}
+
 /**
  * Find image URLs in markdown, push each to a Blossom server, and rewrite
  * the markdown to reference the Blossom-hosted blob.
@@ -376,30 +431,7 @@ export async function rehostImagesInMarkdown(
 
   for (const url of urls) {
     try {
-      let blob: BlobDescriptor
-      if (mode === 'mirror') {
-        const authTpl = createAuthEventTemplate({
-          action: 'upload',
-          content: 'Mirror image from RSS import',
-          expiration: Math.floor(Date.now() / 1000) + ttl,
-        })
-        const authEvent = (await opts.signer.signEvent(authTpl)) as NostrEvent
-        blob = await mirrorBlob(primary, url, authEvent)
-      } else {
-        const res = await fetch(url)
-        if (!res.ok) throw new RssError(`Image fetch failed: ${res.status}`, 'IMG_FETCH')
-        const data = new Uint8Array(await res.arrayBuffer())
-        const hash = bytesToHex(sha256(data))
-        const authTpl = createAuthEventTemplate({
-          action: 'upload',
-          content: 'Upload image from RSS import',
-          expiration: Math.floor(Date.now() / 1000) + ttl,
-          hashes: [hash],
-          size: data.length,
-        })
-        const authEvent = (await opts.signer.signEvent(authTpl)) as NostrEvent
-        blob = await uploadBlob(primary, data, authEvent, res.headers.get('content-type') ?? undefined)
-      }
+      const blob = await rehostImageUrl(url, { server: primary, mode, ttl, signer: opts.signer })
       blobs.push(blob)
       remap.set(url, blob.url)
     } catch {
@@ -464,6 +496,21 @@ export async function importFeedAsDrafts(
         signer: opts.signer,
       })
       article.content = markdown
+
+      // The cover travels in the `image` tag, not the body, so rehost it too.
+      if (article.image) {
+        try {
+          const blob = await rehostImageUrl(article.image, {
+            server: opts.blossom.servers.filter(Boolean)[0],
+            mode: opts.blossom.mode ?? 'mirror',
+            ttl: 300,
+            signer: opts.signer,
+          })
+          article.image = blob.url
+        } catch {
+          // Keep the original cover URL if rehosting fails.
+        }
+      }
     }
 
     const tpl = createLongFormEventTemplate({ ...article, isDraft: asDraft })


### PR DESCRIPTION
## The bug

Importing a feed whose items carry a cover image (enclosure / `media:content`) plus the same picture as the first element of the body - which is how most blog feeds are built, including our own `/blog/feed.xml` - produced articles that display the picture **twice**: once from the NIP-23 `image` tag, once inline at the top of the long-form body. With Blossom rehosting enabled it got stranger still: the inline copy moved to the user's Blossom server while the cover stayed on the source host.

## The fix

- **`itemToDraft` dedupes the cover.** When the markdown body starts with an image matching `item.image` (same URL ignoring extension and query, so `cover.svg` matches `cover.png?w=600`), the body copy is stripped and only the `image` tag remains. New `keepLeadingImage: true` option opts out.
- **`importFeedAsDrafts` rehosts the cover too.** The `blossom` option previously rewrote only body images. The cover in the `image` tag now goes through the same mirror/upload path (shared `rehostImageUrl` helper extracted from `rehostImagesInMarkdown`), keeping the original URL if rehosting fails.
- Docs updated (`docs/api/rss.md`): new option, dedupe behavior, and the widened blossom description.

## Verification

Ran the real pipeline against the generated blog feed plus a mock Blossom server (PUT `/mirror`):

1. Default import: body no longer starts with the image, first line is the `# Title`, cover tag intact.
2. `keepLeadingImage: true`: leading image preserved.
3. Blossom mirror with a body image present: body image **and** cover both mirrored, cover tag rewritten to the Blossom URL.
4. Default + blossom: exactly one mirror call (the cover), clean body.

Re-running an import after this fix replaces earlier doubled articles automatically: the derived `d`-tag is unchanged, so the corrected events overwrite the old ones on relays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)